### PR TITLE
Ignore option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /_build
 /deps
+/doc
 erl_crash.dump
 *.ez
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ This is a library for converting character code.
 
 iex> CCC.convert "概ねアグリー", "UTF-8", "EUC-JP"
 <<179, 181, 164, 205, 165, 162, 165, 176, 165, 234, 161, 188>>
+
+iex> CCC.convert "🍺", "UTF-8", "EUC-JP", discard_unsupported: true
+""
 ```
 
 CCC uses libiconv. Please refer to [the documents](http://www.gnu.org/software/libiconv/).

--- a/c_src/iconv_nif.c
+++ b/c_src/iconv_nif.c
@@ -63,7 +63,7 @@ static ERL_NIF_TERM ccc_iconv_convert(ErlNifEnv* env, int argc, const ERL_NIF_TE
 }
 
 static ErlNifFunc nif_functions[] = {
-    {"convert", 3, ccc_iconv_convert}
+    {"do_convert", 3, ccc_iconv_convert}
 };
 
 ERL_NIF_INIT(Elixir.CCC, nif_functions, 0, 0, 0, NULL);

--- a/lib/ccc.ex
+++ b/lib/ccc.ex
@@ -1,6 +1,6 @@
 defmodule CCC do
   @moduledoc """
-  This module provides a function `convert/3`.
+  This module provides a function `convert/4`.
   It converts characterset of given string from `from` to `to`.
 
       iex> hello_euc = CCC.convert "こんにちわ", "UTF-8", "EUC-JP"
@@ -19,17 +19,23 @@ defmodule CCC do
     |> :erlang.load_nif(0)
   end
 
-  @spec convert(String.t, Strings.t, String.t) :: String.t | {:error, String.t}
+  @spec convert(String.t, String.t, String.t, Keyword.t) :: String.t | {:error, String.t}
   @doc """
   Perform the characterset conversion and returns the result.
 
   See [libiconv documents](http://www.gnu.org/software/libiconv/) for more info.
-  """
-  def convert(_string, _from, _to), do: exit(:nif_not_loaded)
 
-  def convert(string, from, to, opts) do
+  ### options
+
+  - `discard_unsupported`: If `true`, the characters that can't be represented in `to` code will be discarded.
+  """
+  def convert(string, from, to, opts \\ []) do
     if Keyword.get(opts, :discard_unsupported, false) do
-      convert(string, from, to <> "//IGNORE")
+      do_convert(string, from, to <> "//IGNORE")
+    else
+      do_convert(string, from, to)
     end
   end
+
+  defp do_convert(_string, _from, _to), do: exit(:nif_not_loaded)
 end

--- a/lib/ccc.ex
+++ b/lib/ccc.ex
@@ -1,13 +1,24 @@
 defmodule CCC do
   @moduledoc """
   This module provides a function `convert/4`.
-  It converts characterset of given string from `from` to `to`.
+  It converts characterset of given `string` from `from` to `to`.
 
       iex> hello_euc = CCC.convert "こんにちわ", "UTF-8", "EUC-JP"
       <<164, 179, 164, 243, 164, 203, 164, 193, 164, 239>>
 
       iex> CCC.convert hello_euc, "EUC-JP", "UTF-8"
       "こんにちわ"
+
+  If the `string` contains letters that can't be represented in `to` charscter set,
+  `{:error, "invalid multibyte sequence"}` is returned.
+
+      iex> CCC.convert "🍣", "UTF-8", "EUC-JP"
+      {:error, "invalid multibyte sequence"}
+
+  Give `discard_unsupported: true` when you want them to be ignored.
+
+      iex> CCC.convert "🍣", "UTF-8", "EUC-JP", discard_unsupported: true
+      ""
   """
 
   @on_load {:init, 0}

--- a/lib/ccc.ex
+++ b/lib/ccc.ex
@@ -26,4 +26,10 @@ defmodule CCC do
   See [libiconv documents](http://www.gnu.org/software/libiconv/) for more info.
   """
   def convert(_string, _from, _to), do: exit(:nif_not_loaded)
+
+  def convert(string, from, to, opts) do
+    if Keyword.get(opts, :discard_unsupported, false) do
+      convert(string, from, to <> "//IGNORE")
+    end
+  end
 end

--- a/test/ccc_test.exs
+++ b/test/ccc_test.exs
@@ -21,4 +21,14 @@ defmodule CCCTest do
     assert C.convert(@eucjp, "EUC-JP", "Shift_JIS") == @sjis
     assert C.convert(@sjis,  "Shift_JIS", "EUC-JP") == @eucjp
   end
+
+  test "cannot covert unsupported multibyte sequence" do
+    {:error, msg} = C.convert("私は🍣が好きです", "UTF-8", "EUC-JP")
+    assert msg =~ ~r/invalid multibyte sequence/i
+  end
+
+  test "discard unsupported character" do
+    euc = C.convert("私は🍣が好きです", "UTF-8", "EUC-JP", discard_unsupported: true)
+    assert C.convert(euc, "EUC-JP", "UTF-8") == "私はが好きです"
+  end
 end

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,6 +1,19 @@
 box: trenpixster/elixir:1.0.5
 build:
   steps:
+    - install-packages:
+      packages: gnulib
+    - script:
+      name: Install libiconv
+      code: |
+        curl -O http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.14.tar.gz
+        tar zxf libiconv-1.14.tar.gz
+        pushd libiconv-1.14
+        ./configure --prefix=/usr/local
+        make
+        sudo make install
+        sudo ldconfig
+        popd
     - script:
       name: Mix test
       code: |

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,19 +1,10 @@
-box: trenpixster/elixir:1.0.5
+box: xtity/docker-centos7-elixir
 build:
   steps:
-    - install-packages:
-      packages: gnulib
     - script:
-      name: Install libiconv
+      name: Install packages
       code: |
-        curl -O http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.14.tar.gz
-        tar zxf libiconv-1.14.tar.gz
-        pushd libiconv-1.14
-        ./configure --prefix=/usr/local
-        make
-        sudo make install
-        sudo ldconfig
-        popd
+        yum -y install libiconv-devel
     - script:
       name: Mix test
       code: |


### PR DESCRIPTION
This PR add a feature like below

``` elixir
iex> CCC.convert("🍣食べたい", "UTF-8", "EUC-JP", discard_unsupported: true)
"食べたい"
```

When characters that can't be represented in EUC-JP like emoji are included in the string,
current implementation returns `{:error, msg}` tuple.
